### PR TITLE
[feat] Add mds_api_version parameter in dingo.yaml

### DIFF
--- a/pkg/cli/dingocli.go
+++ b/pkg/cli/dingocli.go
@@ -108,15 +108,6 @@ func newDingoCommand() *cobra.Command {
 		Short:   "dingo is a tool for managing dingofs",
 		Version: version.Version,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if cmd.HasParent() {
-				skipCommands := map[string]bool{
-					"help":    true,
-					"version": true,
-				}
-				if !skipCommands[cmd.Name()] {
-					config.InitConfig()
-				}
-			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -145,6 +136,7 @@ func newDingoCommand() *cobra.Command {
 }
 
 func Execute() {
+	config.InitConfig()
 	res := newDingoCommand().Execute()
 	if res != nil {
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ const (
 	DEFAULT_VERBOSE                = false
 	VIPER_GLOBALE_MAX_CHANNEL_SIZE = "global.maxChannelSize"
 	DEFAULT_MAX_CHANNEL_SIZE       = int32(4)
+	VIPER_GLOBALE_MDS_API_VERSION  = "global.mds_api_version"
 )
 
 const (
@@ -73,15 +74,6 @@ var (
 		SHOWERROR, HTTPTIMEOUT, RPCTIMEOUT, RPCRETRYTIMES, VERBOSE,
 	}
 )
-
-func init() {
-	mds_api := os.Getenv("MDS_API")
-	if mds_api == "2" {
-		MDSApiV2 = true
-	} else {
-		MDSApiV2 = false
-	}
-}
 
 func InitConfig() {
 	// configure file priority
@@ -107,6 +99,20 @@ func InitConfig() {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			log.Printf("config file name: %v", viper.ConfigFileUsed())
 			cobra.CheckErr(err)
+		}
+	}
+
+	// check mds api version, env MDS_API_VERSION priority > config file
+	MDSApiV2 = false
+	mdsApiVersion := os.Getenv("MDS_API_VERSION")
+	if mdsApiVersion == "2" {
+		MDSApiV2 = true
+		return
+	}
+	if len(mdsApiVersion) == 0 { // env not set, check config file
+		mdsApiVersion = viper.GetString(VIPER_GLOBALE_MDS_API_VERSION)
+		if mdsApiVersion == "2" {
+			MDSApiV2 = true
 		}
 	}
 }


### PR DESCRIPTION

dingo.yaml配置文件增加mds_api_version参数
[yansp@dingofs-6 .dingo]$ cat dingo.yaml 
global:
  httpTimeout: 500ms
  rpcTimeout: 30s
  showError: false
  mds_api_version: 2 <-mdsv2版本

环境变量MDS_API改成了MDS_API_VERSION
export MDS_API_VERSION=2

环境变量配置的MDS_API_VERSION优先级大于dingo.yaml中的 mds_api_version